### PR TITLE
FURNACE-69: EventListeners as Services

### DIFF
--- a/api/src/main/java/org/jboss/forge/furnace/container/simple/EventListener.java
+++ b/api/src/main/java/org/jboss/forge/furnace/container/simple/EventListener.java
@@ -9,10 +9,12 @@ package org.jboss.forge.furnace.container.simple;
 import java.lang.annotation.Annotation;
 
 /**
+ * Event Listeners can be registered as services.
+ * 
  * <p>
- * To register an {@link EventListener}, a file must be created with the name
- * <code>META-INF/services/org.jboss.forge.furnace.container.simple.EventListener</code>, and each {@link EventListener}
- * implementation type name must be added on a separate line:
+ * To register an {@link EventListener}, register it as {@link Service} or {@link SingletonService}. You can also create
+ * a file with the name <code>META-INF/services/org.jboss.forge.furnace.container.simple.EventListener</code>, and each
+ * {@link EventListener} implementation type name must be added on a separate line:
  * <p>
  * 
  * <pre>
@@ -35,7 +37,8 @@ import java.lang.annotation.Annotation;
  * </pre>
  * 
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * 
+ * @see Service
+ * @see SingletonService
  */
 public interface EventListener
 {

--- a/tests/src/test/java/org/jboss/forge/furnace/container/simple/EventListenerTest.java
+++ b/tests/src/test/java/org/jboss/forge/furnace/container/simple/EventListenerTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jboss.forge.furnace.container.simple;
+
+import java.lang.annotation.Annotation;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.addons.AddonRegistry;
+import org.jboss.forge.furnace.container.simple.lifecycle.SimpleContainer;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@RunWith(Arquillian.class)
+public class EventListenerTest
+{
+   @Deployment
+   @AddonDependencies
+   public static AddonArchive getDeployment()
+   {
+      AddonArchive archive = ShrinkWrap.create(AddonArchive.class)
+               .addAsServiceProvider(Service.class, EventListenerTest.class, FooEventListener.class);
+      return archive;
+   }
+
+   @Test
+   public void testFireEvent()
+   {
+      Furnace furnace = SimpleContainer.getFurnace(this.getClass().getClassLoader());
+      AddonRegistry addonRegistry = furnace.getAddonRegistry();
+      addonRegistry.getEventManager().fireEvent("Foo");
+      Assert.assertTrue("Event was not received", FooEventListener.eventFired);
+   }
+
+   public static class FooEventListener implements EventListener
+   {
+      public static boolean eventFired;
+
+      @Override
+      public void handleEvent(Object event, Annotation... qualifiers)
+      {
+         Logger.getGlobal().log(Level.FINE, "##########EVENT: %s %s %n", new Object[] { event.getClass(), event });
+         eventFired = "Foo".equals(event);
+      }
+   }
+
+}


### PR DESCRIPTION
By allowing registering an EventListener as a service, it is possible not only
to reuse the service lookup logic, but also to have singleton event listeners 
by registering as a SingletonService.